### PR TITLE
Prevents vanilla warp events after warp cleansing

### DIFF
--- a/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
@@ -28,6 +28,7 @@ public class WarpHandler
     public static Map<String, Integer> warpNormal;
     public static Map<String, Integer> warpTemp;
     public static Map<String, Integer> warpPermanent;
+    public static Map<String, Integer> warpCount;
     public static boolean wuss = false;
     public static int potionWarpWardID = -1;
 
@@ -157,6 +158,7 @@ public class WarpHandler
             warpNormal = (Map<String, Integer>)pK.getClass().getDeclaredField("warpSticky").get(pK);
             warpTemp = (Map<String, Integer>)pK.getClass().getField("warpTemp").get(pK);
             warpPermanent = (Map<String, Integer>)pK.getClass().getField("warp").get(pK);
+            warpCount = (Map<String, Integer>)pK.getClass().getField("warpCount").get(pK);
         }
         catch (Exception e)
         {
@@ -211,6 +213,12 @@ public class WarpHandler
             int wp = warpPermanent != null ? warpPermanent.get(name) : 0;
             int wn = warpNormal.get(name);
             int wt = warpTemp.get(name);
+            // reset the warp counter so
+            // 1) if partial warp reduction, reset the counter so vanilla TC warp events would fire
+            //    the same behavior can be observed on TC sanitizing soap
+            // 2) if total warp reduction, the counter would be reduced to 0, so vanilla TC warp events would
+            //    no longer fire
+            warpCount.put(name, wp + wn + wt - amount);
             if (amount <= wt)
             {
                 warpTemp.put(name, wt - amount);


### PR DESCRIPTION
Currently, vanilla TC warp events would fire if you
1. get some serious warp, e.g. reading a tome of sharing and unlock all research. This would result in some massive warp.
2. use pure tear to remove all of them
3. gain some tiny warp via Warping 1 tools (so you now have 0 perm warp, 0 normal warp and 0 temp warp, and 1 equipment warp)
4. Wait for a few minutes with that warping tool in hand
5. Severe warp events fires, as opposed to the very low severity gain knowledge event.

## Some background knowledge:
* Vanilla TC having a warp counter.
   * This counter will be set to your current warp whenever you gain or loss perm/normal/temp warp. 
   * This counter will eventually drop to 0 as time goes by. 
   * It won't reset when you switch on/off warping equipments. 
* TC calculates warp severity, by taking a weighted average over (perm+normal+temp+equipment warp) and counter. 
---
In our case, if current warp is 0+1 (as is after warp cleansing with 1 warping 1 tool) but the counter hasn't reset (so probably >500 in my case), TC warp code would see the player as having extremely heavy warp. This will definitely spawn negative warp effects.

This PR resets the counter as if a mega sized sanitizing soap is used.