### PR TITLE
Cleaned some code and make Warp Ward to prevent actual effect.

### DIFF
--- a/src/main/java/shukaro/warptheory/WarpTheory.java
+++ b/src/main/java/shukaro/warptheory/WarpTheory.java
@@ -1,6 +1,5 @@
 package shukaro.warptheory;
 
-import cpw.mods.fml.client.event.ConfigChangedEvent;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.SidedProxy;
@@ -8,7 +7,6 @@ import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.registry.EntityRegistry;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.util.StatCollector;
@@ -34,7 +32,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 
 @Mod(modid = Constants.modID, name = Constants.modName, version = Constants.modVersion, guiFactory = "shukaro.warptheory.gui.GuiFactory",
-        dependencies = "required-after:Forge@[10.13.2,);required-after:Baubles;required-after:Thaumcraft")
+        dependencies = "required-after:Forge@[10.13.2,);required-after:Baubles;required-after:Thaumcraft@[4.2.3.5,);")
 public class WarpTheory {
     @SidedProxy(clientSide = "shukaro.warptheory.net.ClientProxy", serverSide = "shukaro.warptheory.net.CommonProxy")
     public static CommonProxy proxy;
@@ -92,7 +90,6 @@ public class WarpTheory {
 
     @Mod.EventHandler
     public void postInit(FMLPostInitializationEvent evt) {
-        WarpHandler.tcReflect();
         WarpResearch.init();
     }
 }

--- a/src/main/java/shukaro/warptheory/handlers/ConfigHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/ConfigHandler.java
@@ -84,7 +84,7 @@ public class ConfigHandler {
     private static void loadConfiguration()
     {
         wussMode = config.getBoolean("wussMode", "general", false, "enables less expensive recipes");
-        disableRebound = config.getBoolean("disableRebound", "general", false, "disable warp events ignoring warpwarding which occur by purify tear");
+        disableRebound = config.getBoolean("disableRebound", "general", false, "disable warp events ignoring warpwarding which occur by Pure Tear");
         permWarpMult = config.getInt("permWarpMult", "general", 4, 0, Integer.MAX_VALUE, "how much more 'expensive' permanent warp is compared to normal warp");
         allowPermWarpRemoval = config.getBoolean("allowPermWarpRemoval", "general", true, "whether items can remove permanent warp or not");
         allowGlobalWarpEffects = config.getBoolean("allowGlobalWarpEffects", "general", true, "whether warp effects that involve the environment are triggered");

--- a/src/main/java/shukaro/warptheory/handlers/ConfigHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/ConfigHandler.java
@@ -3,8 +3,6 @@ package shukaro.warptheory.handlers;
 import cpw.mods.fml.client.event.ConfigChangedEvent;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.common.config.Configuration;
-import shukaro.warptheory.recipe.WarpRecipes;
-import shukaro.warptheory.research.WarpResearch;
 import shukaro.warptheory.util.Constants;
 
 import java.io.File;
@@ -16,6 +14,7 @@ public class ConfigHandler {
 
     public static Configuration config;
     public static boolean wussMode = false;
+    public static boolean disableRebound = false;
     public static int permWarpMult = 4;
     public static boolean allowPermWarpRemoval = true;
     public static boolean allowGlobalWarpEffects = false;
@@ -85,6 +84,7 @@ public class ConfigHandler {
     private static void loadConfiguration()
     {
         wussMode = config.getBoolean("wussMode", "general", false, "enables less expensive recipes");
+        disableRebound = config.getBoolean("disableRebound", "general", false, "disable warp events ignoring warpwarding which occur by purify tear");
         permWarpMult = config.getInt("permWarpMult", "general", 4, 0, Integer.MAX_VALUE, "how much more 'expensive' permanent warp is compared to normal warp");
         allowPermWarpRemoval = config.getBoolean("allowPermWarpRemoval", "general", true, "whether items can remove permanent warp or not");
         allowGlobalWarpEffects = config.getBoolean("allowGlobalWarpEffects", "general", true, "whether warp effects that involve the environment are triggered");

--- a/src/main/java/shukaro/warptheory/handlers/IWarpEvent.java
+++ b/src/main/java/shukaro/warptheory/handlers/IWarpEvent.java
@@ -2,6 +2,8 @@ package shukaro.warptheory.handlers;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
+import static thaumcraft.common.config.Config.potionWarpWardID;
+import static thaumcraft.common.config.Config.wuss;
 
 public abstract class IWarpEvent
 {
@@ -11,7 +13,13 @@ public abstract class IWarpEvent
 
     public final int getCost() { return (int)Math.ceil(getSeverity() / (double)10); }
 
-    public boolean canDo(EntityPlayer player) { return true; }
+	public boolean canDo(EntityPlayer player) {
+		boolean flag = true;
+		flag = !player.isPotionActive(potionWarpWardID) || (WarpHandler.getUnavoidableCount(player) > 0);
+		WarpHandler.addUnavoidableCount(player, -1);
+		flag &= !(wuss||player.capabilities.isCreativeMode);
+		return flag;
+	}
 
     public abstract boolean doEvent(World world, EntityPlayer player);
 }

--- a/src/main/java/shukaro/warptheory/handlers/IWarpEvent.java
+++ b/src/main/java/shukaro/warptheory/handlers/IWarpEvent.java
@@ -13,13 +13,12 @@ public abstract class IWarpEvent
 
     public final int getCost() { return (int)Math.ceil(getSeverity() / (double)10); }
 
-	public boolean canDo(EntityPlayer player) {
-		boolean flag = true;
-		flag = !player.isPotionActive(potionWarpWardID) || (WarpHandler.getUnavoidableCount(player) > 0);
-		WarpHandler.addUnavoidableCount(player, -1);
-		flag &= !(wuss||player.capabilities.isCreativeMode);
-		return flag;
-	}
+    public boolean canDo(EntityPlayer player)
+    {
+        boolean flag = !player.isPotionActive(potionWarpWardID) || (WarpHandler.getUnavoidableCount(player) > 0) && !(wuss||player.capabilities.isCreativeMode);
+        WarpHandler.addUnavoidableCount(player, -1);
+        return flag;
+    }
 
     public abstract boolean doEvent(World world, EntityPlayer player);
 }

--- a/src/main/java/shukaro/warptheory/handlers/WarpEventHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpEventHandler.java
@@ -18,14 +18,15 @@ public class WarpEventHandler
             boolean tickflag = !player.worldObj.isRemote && player.ticksExisted > 0 && player.ticksExisted % 2000 == 0;
             if (tickflag && appliable && WarpHandler.getTotalWarp(player) > 0 && player.worldObj.rand.nextInt(100) <= Math.sqrt(WarpHandler.getTotalWarp(player)))
             {
-				IWarpEvent event = WarpHandler.queueOneEvent(player, WarpHandler.getTotalWarp(player));
-				if (event != null) {
-					int warpTemp = WarpHandler.getIndividualWarps(player)[2];
-					if (warpTemp > 0 && event.getCost() <= warpTemp)
-						WarpHandler.removeWarp(player, event.getCost());
-					else if (warpTemp > 0)
-						WarpHandler.removeWarp(player, warpTemp);
-				}
+                IWarpEvent event = WarpHandler.queueOneEvent(player, WarpHandler.getTotalWarp(player));
+                if (event != null)
+                {
+                    int warpTemp = WarpHandler.getIndividualWarps(player)[2];
+                    if (warpTemp > 0 && event.getCost() <= warpTemp)
+                        WarpHandler.removeWarp(player, event.getCost());
+                    else if (warpTemp > 0)
+                        WarpHandler.removeWarp(player, warpTemp);
+                }
             }
             if (player.ticksExisted % 20 == 0 && player.worldObj.rand.nextBoolean())
             {

--- a/src/main/java/shukaro/warptheory/handlers/WarpEventHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpEventHandler.java
@@ -3,6 +3,8 @@ package shukaro.warptheory.handlers;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.event.entity.living.LivingEvent;
+import static thaumcraft.common.config.Config.potionWarpWardID;
+import static thaumcraft.common.config.Config.wuss;
 
 public class WarpEventHandler
 {
@@ -12,18 +14,19 @@ public class WarpEventHandler
         if (e.entity instanceof EntityPlayer)
         {
             EntityPlayer player = (EntityPlayer)e.entity;
-            if (player.ticksExisted % 2000 == 0 && !WarpHandler.wuss && !player.isPotionActive(WarpHandler.potionWarpWardID) && WarpHandler.getTotalWarp(player) > 0 &&
-                    !player.capabilities.isCreativeMode && !player.worldObj.isRemote && player.worldObj.rand.nextInt(100) <= Math.sqrt(WarpHandler.getTotalWarp(player)))
+            boolean appliable = !player.isPotionActive(potionWarpWardID) || (WarpHandler.getUnavoidableCount(player) > 0);
+            appliable &= !wuss && !player.capabilities.isCreativeMode;
+            boolean tickflag = !player.worldObj.isRemote && player.ticksExisted > 0 && player.ticksExisted % 2000 == 0;
+            if (tickflag && appliable && WarpHandler.getTotalWarp(player) > 0 && player.worldObj.rand.nextInt(100) <= Math.sqrt(WarpHandler.getTotalWarp(player)))
             {
-                IWarpEvent event = WarpHandler.queueOneEvent(player, WarpHandler.getTotalWarp(player));
-                if (event != null)
-                {
-                    int warpTemp = WarpHandler.getIndividualWarps(player)[2];
-                    if (warpTemp > 0 && event.getCost() <= warpTemp)
-                        WarpHandler.removeWarp(player, event.getCost());
-                    else if (warpTemp > 0)
-                        WarpHandler.removeWarp(player, warpTemp);
-                }
+				IWarpEvent event = WarpHandler.queueOneEvent(player, WarpHandler.getTotalWarp(player));
+				if (event != null) {
+					int warpTemp = WarpHandler.getIndividualWarps(player)[2];
+					if (warpTemp > 0 && event.getCost() <= warpTemp)
+						WarpHandler.removeWarp(player, event.getCost());
+					else if (warpTemp > 0)
+						WarpHandler.removeWarp(player, warpTemp);
+				}
             }
             if (player.ticksExisted % 20 == 0 && player.worldObj.rand.nextBoolean())
             {

--- a/src/main/java/shukaro/warptheory/handlers/WarpEventHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpEventHandler.java
@@ -14,8 +14,7 @@ public class WarpEventHandler
         if (e.entity instanceof EntityPlayer)
         {
             EntityPlayer player = (EntityPlayer)e.entity;
-            boolean appliable = !player.isPotionActive(potionWarpWardID) || (WarpHandler.getUnavoidableCount(player) > 0);
-            appliable &= !wuss && !player.capabilities.isCreativeMode;
+            boolean appliable = !player.isPotionActive(potionWarpWardID) || (WarpHandler.getUnavoidableCount(player) > 0) && !wuss && !player.capabilities.isCreativeMode;
             boolean tickflag = !player.worldObj.isRemote && player.ticksExisted > 0 && player.ticksExisted % 2000 == 0;
             if (tickflag && appliable && WarpHandler.getTotalWarp(player) > 0 && player.worldObj.rand.nextInt(100) <= Math.sqrt(WarpHandler.getTotalWarp(player)))
             {

--- a/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
@@ -156,7 +156,7 @@ public class WarpHandler
 			ChatHelper.sendToPlayer(player, StatCollector.translateToLocal("chat.warptheory.purgefailed"));
     }
 	
-	public static void removeWarp(EntityPlayer player, int amount)
+    public static void removeWarp(EntityPlayer player, int amount)
     {
 		if (amount <= 0)
 			return;

--- a/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
@@ -156,7 +156,8 @@ public class WarpHandler
 			ChatHelper.sendToPlayer(player, StatCollector.translateToLocal("chat.warptheory.purgefailed"));
     }
 	
-	public static void removeWarp(EntityPlayer player, int amount) {
+	public static void removeWarp(EntityPlayer player, int amount)
+    {
 		if (amount <= 0)
 			return;
 		String name = player.getDisplayName();
@@ -188,13 +189,13 @@ public class WarpHandler
 		}
 	}
 
-    public static final int getTotalWarp(EntityPlayer player)
+    public static int getTotalWarp(EntityPlayer player)
     {
     	String name = player.getDisplayName();
     	int innerWarp = Knowledge.getWarpTotal(name);
     	int extraPerm = Knowledge.getWarpPerm(name) * (int) Math.max(0, ConfigHandler.permWarpMult - 1);
     	int outerWarp = getWarpFromGear(player);
-    	return innerWarp+extraPerm+outerWarp;
+    	return innerWarp + extraPerm + outerWarp;
     }
 
     public static int[] getIndividualWarps(EntityPlayer player)
@@ -239,7 +240,7 @@ public class WarpHandler
         return null;
     }
 
-    public static final int getWarpFromGear(EntityPlayer player)
+    public static int getWarpFromGear(EntityPlayer player)
     {
         int w = getFinalWarp(player.getCurrentEquippedItem(), player);
         for (int a = 0; a < 4; a++)
@@ -250,7 +251,8 @@ public class WarpHandler
         return w;
     }
 
-	public static final int getFinalWarp(ItemStack stack, EntityPlayer player) {
+	public static int getFinalWarp(ItemStack stack, EntityPlayer player)
+    {
 		if (stack == null || !(stack.getItem() instanceof IWarpingGear))
 			return 0;
 		IWarpingGear armor = (IWarpingGear) stack.getItem();
@@ -301,25 +303,30 @@ public class WarpHandler
         return null;
     }
     
-    public static void setUnavoidableCount(EntityPlayer player, int count) {
-    	if(ConfigHandler.disableRebound) return;
+    public static void setUnavoidableCount(EntityPlayer player, int count)
+    {
+    	if(ConfigHandler.disableRebound)
+    		return;
     	UUID uuid = EntityPlayer.func_146094_a(player.getGameProfile());
     	Unavoidable.put(uuid, Math.max(0,count));
     }
     
-    public static void addUnavoidableCount(EntityPlayer player, int count) {
-    	if(ConfigHandler.disableRebound) return;
+    public static void addUnavoidableCount(EntityPlayer player, int count)
+    {
+    	if(ConfigHandler.disableRebound)
+    		return;
     	UUID uuid = EntityPlayer.func_146094_a(player.getGameProfile());
     	count = Math.max(0,count + Unavoidable.get(uuid));
     	Unavoidable.put(uuid, count);
     }
     
-    public static int getUnavoidableCount(EntityPlayer player) {
-    	if(ConfigHandler.disableRebound) return 0;
+    public static int getUnavoidableCount(EntityPlayer player)
+    {
+    	if(ConfigHandler.disableRebound)
+    		return 0;
     	UUID uuid = EntityPlayer.func_146094_a(player.getGameProfile());
-    	if(!Unavoidable.containsKey(uuid)) {
+    	if(!Unavoidable.containsKey(uuid))
     		Unavoidable.put(uuid, 0);
-    	}
     	return Unavoidable.get(uuid);
     }
 }

--- a/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
@@ -190,11 +190,11 @@ public class WarpHandler
 
     public static int getTotalWarp(EntityPlayer player)
     {
-    	String name = player.getDisplayName();
-    	int innerWarp = Knowledge.getWarpTotal(name);
-    	int extraPerm = Knowledge.getWarpPerm(name) * (int) Math.max(0, ConfigHandler.permWarpMult - 1);
-    	int outerWarp = getWarpFromGear(player);
-    	return innerWarp + extraPerm + outerWarp;
+        String name = player.getDisplayName();
+        int innerWarp = Knowledge.getWarpTotal(name);
+        int extraPerm = Knowledge.getWarpPerm(name) * (int) Math.max(0, ConfigHandler.permWarpMult - 1);
+        int outerWarp = getWarpFromGear(player);
+        return innerWarp + extraPerm + outerWarp;
     }
 
     public static int[] getIndividualWarps(EntityPlayer player)
@@ -243,7 +243,7 @@ public class WarpHandler
     {
         int w = getFinalWarp(player.getCurrentEquippedItem(), player);
         for (int a = 0; a < 4; a++)
-            w += getFinalWarp(player.inventory.armorItemInSlot(a), player); 
+            w += getFinalWarp(player.inventory.armorItemInSlot(a), player);
         IInventory baubles = BaublesApi.getBaubles(player);
         for (int i = 0; i < 4; i++)
             w += getFinalWarp(baubles.getStackInSlot(i), player); 

--- a/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
@@ -306,7 +306,7 @@ public class WarpHandler
     {
         if(ConfigHandler.disableRebound)
             return;
-        UUID uuid = EntityPlayer.func_146094_a(player.getGameProfile());
+        UUID uuid = player.getUniqueID();
         Unavoidable.put(uuid, Math.max(0,count));
     }
     
@@ -314,7 +314,7 @@ public class WarpHandler
     {
         if(ConfigHandler.disableRebound)
             return;
-        UUID uuid = EntityPlayer.func_146094_a(player.getGameProfile());
+        UUID uuid = player.getUniqueID();
         count = Math.max(0,count + Unavoidable.get(uuid));
         Unavoidable.put(uuid, count);
     }
@@ -323,7 +323,7 @@ public class WarpHandler
     {
         if(ConfigHandler.disableRebound)
             return 0;
-        UUID uuid = EntityPlayer.func_146094_a(player.getGameProfile());
+        UUID uuid = player.getUniqueID();
         if(!Unavoidable.containsKey(uuid))
             Unavoidable.put(uuid, 0);
         return Unavoidable.get(uuid);

--- a/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
@@ -29,8 +29,8 @@ import thaumcraft.common.lib.research.PlayerKnowledge;
 
 public class WarpHandler
 {
-	public static final PlayerKnowledge Knowledge = Thaumcraft.proxy.getPlayerKnowledge();
-	private static HashMap<UUID, Integer> Unavoidable = new HashMap<UUID, Integer>();
+    public static final PlayerKnowledge Knowledge = Thaumcraft.proxy.getPlayerKnowledge();
+    private static HashMap<UUID, Integer> Unavoidable = new HashMap<UUID, Integer>();
     public static ArrayList<IWarpEvent> warpEvents = new ArrayList<IWarpEvent>();
 
     public static Map<NameMetaPair, NameMetaPair> decayMappings = new THashMap<NameMetaPair, NameMetaPair>();
@@ -158,36 +158,35 @@ public class WarpHandler
 	
     public static void removeWarp(EntityPlayer player, int amount)
     {
-		if (amount <= 0)
-			return;
-		String name = player.getDisplayName();
-		int wp = Knowledge.getWarpPerm(name);
-		int wn = Knowledge.getWarpSticky(name);
-		int wt = Knowledge.getWarpTemp(name);
-		// reset the warp counter so
-		// 1) if partial warp reduction, reset the counter so vanilla TC warp events
-		// would fire
-		// the same behavior can be observed on TC sanitizing soap
-		// 2) if total warp reduction, the counter would be reduced to 0, so vanilla TC
-		// warp events would
-		// no longer fire
-		Knowledge.setWarpCounter(name, wp + wn + wt - amount);
+        if (amount <= 0)
+            return;
+        String name = player.getDisplayName();
+        int wp = Knowledge.getWarpPerm(name);
+        int wn = Knowledge.getWarpSticky(name);
+        int wt = Knowledge.getWarpTemp(name);
+        // reset the warp counter so
+        // 1) if partial warp reduction, reset the counter so vanilla TC warp events would fire
+        //    the same behavior can be observed on TC sanitizing soap
+        // 2) if total warp reduction, the counter would be reduced to 0, so vanilla TC warp events would
+        //    no longer fire
+        Knowledge.setWarpCounter(name, wp + wn + wt - amount);
 
-		Knowledge.addWarpTemp(name, -amount);
-		amount -= wt;
-		if (amount <= 0)
-			return;
+        Knowledge.addWarpTemp(name, -amount);
+        amount -= wt;
+        if (amount <= 0)
+            return;
 
-		Knowledge.addWarpSticky(name, -amount);
-		amount -= wn;
-		if (amount <= 0)
-			return;
+        Knowledge.addWarpSticky(name, -amount);
+        amount -= wn;
+        if (amount <= 0)
+            return;
 
-		if (ConfigHandler.allowPermWarpRemoval) {
-			amount = (int) Math.ceil(amount / ConfigHandler.permWarpMult);
-			Knowledge.addWarpPerm(name, -amount);
-		}
-	}
+        if (ConfigHandler.allowPermWarpRemoval)
+	{
+            amount = (int) Math.ceil(amount / ConfigHandler.permWarpMult);
+            Knowledge.addWarpPerm(name, -amount);
+        }
+    }
 
     public static int getTotalWarp(EntityPlayer player)
     {
@@ -251,13 +250,13 @@ public class WarpHandler
         return w;
     }
 
-	public static int getFinalWarp(ItemStack stack, EntityPlayer player)
+    public static int getFinalWarp(ItemStack stack, EntityPlayer player)
     {
-		if (stack == null || !(stack.getItem() instanceof IWarpingGear))
-			return 0;
-		IWarpingGear armor = (IWarpingGear) stack.getItem();
-		return armor.getWarp(stack, player);
-	}
+        if (stack == null || !(stack.getItem() instanceof IWarpingGear))
+            return 0;
+        IWarpingGear armor = (IWarpingGear) stack.getItem();
+        return armor.getWarp(stack, player);
+    }
 	
     public static IWarpEvent getEventFromName(String name)
     {
@@ -306,7 +305,7 @@ public class WarpHandler
     public static void setUnavoidableCount(EntityPlayer player, int count)
     {
     	if(ConfigHandler.disableRebound)
-    		return;
+            return;
     	UUID uuid = EntityPlayer.func_146094_a(player.getGameProfile());
     	Unavoidable.put(uuid, Math.max(0,count));
     }
@@ -314,7 +313,7 @@ public class WarpHandler
     public static void addUnavoidableCount(EntityPlayer player, int count)
     {
     	if(ConfigHandler.disableRebound)
-    		return;
+            return;
     	UUID uuid = EntityPlayer.func_146094_a(player.getGameProfile());
     	count = Math.max(0,count + Unavoidable.get(uuid));
     	Unavoidable.put(uuid, count);
@@ -322,8 +321,8 @@ public class WarpHandler
     
     public static int getUnavoidableCount(EntityPlayer player)
     {
-    	if(ConfigHandler.disableRebound)
-    		return 0;
+        if(ConfigHandler.disableRebound)
+            return 0;
     	UUID uuid = EntityPlayer.func_146094_a(player.getGameProfile());
     	if(!Unavoidable.containsKey(uuid))
     		Unavoidable.put(uuid, 0);

--- a/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
@@ -214,7 +214,7 @@ public class WarpHandler
             if (event == null)
                 return w;
             w -= event.getCost();
-            count+=1;
+            count += 1;
         }
         return count;
     }

--- a/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
@@ -181,11 +181,11 @@ public class WarpHandler
         if (amount <= 0)
             return;
 
-        if (ConfigHandler.allowPermWarpRemoval)
-	{
+    	if (ConfigHandler.allowPermWarpRemoval)
+    	{
             amount = (int) Math.ceil(amount / ConfigHandler.permWarpMult);
             Knowledge.addWarpPerm(name, -amount);
-        }
+    	}
     }
 
     public static int getTotalWarp(EntityPlayer player)
@@ -199,7 +199,7 @@ public class WarpHandler
 
     public static int[] getIndividualWarps(EntityPlayer player)
     {
-    	String userName = player.getDisplayName();
+        String userName = player.getDisplayName();
         int[] totals = new int[] { Knowledge.getWarpPerm(userName), Knowledge.getWarpSticky(userName), Knowledge.getWarpTemp(userName) };
         return totals;
     }
@@ -243,10 +243,10 @@ public class WarpHandler
     {
         int w = getFinalWarp(player.getCurrentEquippedItem(), player);
         for (int a = 0; a < 4; a++)
-          w += getFinalWarp(player.inventory.armorItemInSlot(a), player); 
+            w += getFinalWarp(player.inventory.armorItemInSlot(a), player); 
         IInventory baubles = BaublesApi.getBaubles(player);
         for (int i = 0; i < 4; i++)
-          w += getFinalWarp(baubles.getStackInSlot(i), player); 
+            w += getFinalWarp(baubles.getStackInSlot(i), player); 
         return w;
     }
 
@@ -304,28 +304,28 @@ public class WarpHandler
     
     public static void setUnavoidableCount(EntityPlayer player, int count)
     {
-    	if(ConfigHandler.disableRebound)
+        if(ConfigHandler.disableRebound)
             return;
-    	UUID uuid = EntityPlayer.func_146094_a(player.getGameProfile());
-    	Unavoidable.put(uuid, Math.max(0,count));
+        UUID uuid = EntityPlayer.func_146094_a(player.getGameProfile());
+        Unavoidable.put(uuid, Math.max(0,count));
     }
     
     public static void addUnavoidableCount(EntityPlayer player, int count)
     {
-    	if(ConfigHandler.disableRebound)
+        if(ConfigHandler.disableRebound)
             return;
-    	UUID uuid = EntityPlayer.func_146094_a(player.getGameProfile());
-    	count = Math.max(0,count + Unavoidable.get(uuid));
-    	Unavoidable.put(uuid, count);
+        UUID uuid = EntityPlayer.func_146094_a(player.getGameProfile());
+        count = Math.max(0,count + Unavoidable.get(uuid));
+        Unavoidable.put(uuid, count);
     }
     
     public static int getUnavoidableCount(EntityPlayer player)
     {
         if(ConfigHandler.disableRebound)
             return 0;
-    	UUID uuid = EntityPlayer.func_146094_a(player.getGameProfile());
-    	if(!Unavoidable.containsKey(uuid))
-    		Unavoidable.put(uuid, 0);
-    	return Unavoidable.get(uuid);
+        UUID uuid = EntityPlayer.func_146094_a(player.getGameProfile());
+        if(!Unavoidable.containsKey(uuid))
+            Unavoidable.put(uuid, 0);
+        return Unavoidable.get(uuid);
     }
 }

--- a/src/main/java/shukaro/warptheory/handlers/warpevents/WarpDecay.java
+++ b/src/main/java/shukaro/warptheory/handlers/warpevents/WarpDecay.java
@@ -44,6 +44,9 @@ public class WarpDecay extends IWarpEvent
     @Override
     public boolean canDo(EntityPlayer player)
     {
+    	if(!super.canDo(player)) {
+    		return false;
+    	}
         for (String n : (Set<String>)MiscHelper.getWarpTag(player).func_150296_c())
         {
             if (n.startsWith("biome") && !n.equals(getName()))

--- a/src/main/java/shukaro/warptheory/handlers/warpevents/WarpDecay.java
+++ b/src/main/java/shukaro/warptheory/handlers/warpevents/WarpDecay.java
@@ -45,9 +45,7 @@ public class WarpDecay extends IWarpEvent
     public boolean canDo(EntityPlayer player)
     {
     	if(!super.canDo(player))
-	{
             return false;
-    	}
         for (String n : (Set<String>)MiscHelper.getWarpTag(player).func_150296_c())
         {
             if (n.startsWith("biome") && !n.equals(getName()))

--- a/src/main/java/shukaro/warptheory/handlers/warpevents/WarpDecay.java
+++ b/src/main/java/shukaro/warptheory/handlers/warpevents/WarpDecay.java
@@ -44,8 +44,9 @@ public class WarpDecay extends IWarpEvent
     @Override
     public boolean canDo(EntityPlayer player)
     {
-    	if(!super.canDo(player)) {
-    		return false;
+    	if(!super.canDo(player))
+	{
+            return false;
     	}
         for (String n : (Set<String>)MiscHelper.getWarpTag(player).func_150296_c())
         {

--- a/src/main/java/shukaro/warptheory/handlers/warpevents/WarpDecay.java
+++ b/src/main/java/shukaro/warptheory/handlers/warpevents/WarpDecay.java
@@ -44,7 +44,7 @@ public class WarpDecay extends IWarpEvent
     @Override
     public boolean canDo(EntityPlayer player)
     {
-    	if(!super.canDo(player))
+        if(!super.canDo(player))
             return false;
         for (String n : (Set<String>)MiscHelper.getWarpTag(player).func_150296_c())
         {

--- a/src/main/java/shukaro/warptheory/handlers/warpevents/WarpFall.java
+++ b/src/main/java/shukaro/warptheory/handlers/warpevents/WarpFall.java
@@ -49,6 +49,9 @@ public class WarpFall extends IWarpEvent
     @Override
     public boolean canDo(EntityPlayer player)
     {
+    	if(!super.canDo(player)) {
+    		return false;
+    	}
         if (originalPositions.get(player.getCommandSenderName()) != null)
             return false;
         return true;

--- a/src/main/java/shukaro/warptheory/handlers/warpevents/WarpFall.java
+++ b/src/main/java/shukaro/warptheory/handlers/warpevents/WarpFall.java
@@ -49,7 +49,7 @@ public class WarpFall extends IWarpEvent
     @Override
     public boolean canDo(EntityPlayer player)
     {
-    	if(!super.canDo(player))
+        if(!super.canDo(player))
             return false;
         if (originalPositions.get(player.getCommandSenderName()) != null)
             return false;

--- a/src/main/java/shukaro/warptheory/handlers/warpevents/WarpFall.java
+++ b/src/main/java/shukaro/warptheory/handlers/warpevents/WarpFall.java
@@ -49,9 +49,8 @@ public class WarpFall extends IWarpEvent
     @Override
     public boolean canDo(EntityPlayer player)
     {
-    	if(!super.canDo(player)) {
-    		return false;
-    	}
+    	if(!super.canDo(player))
+            return false;
         if (originalPositions.get(player.getCommandSenderName()) != null)
             return false;
         return true;

--- a/src/main/java/shukaro/warptheory/handlers/warpevents/WarpSwamp.java
+++ b/src/main/java/shukaro/warptheory/handlers/warpevents/WarpSwamp.java
@@ -48,7 +48,7 @@ public class WarpSwamp extends IWarpEvent
     @Override
     public boolean canDo(EntityPlayer player)
     {
-    	if(!super.canDo(player))
+        if(!super.canDo(player))
             return false;
         for (String n : (Set<String>)MiscHelper.getWarpTag(player).func_150296_c())
         {

--- a/src/main/java/shukaro/warptheory/handlers/warpevents/WarpSwamp.java
+++ b/src/main/java/shukaro/warptheory/handlers/warpevents/WarpSwamp.java
@@ -48,9 +48,8 @@ public class WarpSwamp extends IWarpEvent
     @Override
     public boolean canDo(EntityPlayer player)
     {
-    	if(!super.canDo(player)) {
-    		return false;
-    	}
+    	if(!super.canDo(player))
+            return false;
         for (String n : (Set<String>)MiscHelper.getWarpTag(player).func_150296_c())
         {
             if (n.startsWith("biome") && !n.equals(getName()))

--- a/src/main/java/shukaro/warptheory/handlers/warpevents/WarpSwamp.java
+++ b/src/main/java/shukaro/warptheory/handlers/warpevents/WarpSwamp.java
@@ -48,6 +48,9 @@ public class WarpSwamp extends IWarpEvent
     @Override
     public boolean canDo(EntityPlayer player)
     {
+    	if(!super.canDo(player)) {
+    		return false;
+    	}
         for (String n : (Set<String>)MiscHelper.getWarpTag(player).func_150296_c())
         {
             if (n.startsWith("biome") && !n.equals(getName()))

--- a/src/main/java/shukaro/warptheory/items/ItemSomething.java
+++ b/src/main/java/shukaro/warptheory/items/ItemSomething.java
@@ -89,20 +89,10 @@ public class ItemSomething extends Item
         if (!world.isRemote)
         {
             player.addChatMessage(new ChatComponentText(FormatCodes.Purple.code + FormatCodes.Italic.code + StatCollector.translateToLocal("chat.warptheory.addwarp")));
-            if (WarpHandler.warpPermanent != null)
-            {
-                ThaumcraftApiHelper.addWarpToPlayer(player, 4 + world.rand.nextInt(4), false);
-                ThaumcraftApiHelper.addWarpToPlayer(player, 5 + world.rand.nextInt(5), true);
-                ThaumcraftApiHelper.addStickyWarpToPlayer(player, 5 + world.rand.nextInt(5));
-            }
-            else
-            {
-                ThaumcraftApiHelper.addWarpToPlayer(player, 7 + world.rand.nextInt(7), false);
-                ThaumcraftApiHelper.addWarpToPlayer(player, 7 + world.rand.nextInt(7), true);
-            }
-
+			ThaumcraftApiHelper.addWarpToPlayer(player, 4 + world.rand.nextInt(4), false);
+			ThaumcraftApiHelper.addWarpToPlayer(player, 5 + world.rand.nextInt(5), true);
+			ThaumcraftApiHelper.addStickyWarpToPlayer(player, 5 + world.rand.nextInt(5));
         }
-
         if (!player.capabilities.isCreativeMode)
             stack.stackSize--;
 

--- a/src/main/java/shukaro/warptheory/items/ItemSomething.java
+++ b/src/main/java/shukaro/warptheory/items/ItemSomething.java
@@ -89,9 +89,9 @@ public class ItemSomething extends Item
         if (!world.isRemote)
         {
             player.addChatMessage(new ChatComponentText(FormatCodes.Purple.code + FormatCodes.Italic.code + StatCollector.translateToLocal("chat.warptheory.addwarp")));
-			ThaumcraftApiHelper.addWarpToPlayer(player, 4 + world.rand.nextInt(4), false);
-			ThaumcraftApiHelper.addWarpToPlayer(player, 5 + world.rand.nextInt(5), true);
-			ThaumcraftApiHelper.addStickyWarpToPlayer(player, 5 + world.rand.nextInt(5));
+            ThaumcraftApiHelper.addWarpToPlayer(player, 4 + world.rand.nextInt(4), false);
+            ThaumcraftApiHelper.addWarpToPlayer(player, 5 + world.rand.nextInt(5), true);
+            ThaumcraftApiHelper.addStickyWarpToPlayer(player, 5 + world.rand.nextInt(5));
         }
         if (!player.capabilities.isCreativeMode)
             stack.stackSize--;


### PR DESCRIPTION
update the required dependency of Thaumcraft4, and remove all of reflective init. Which are useless.

In WarpTheory, warpWarding and wuss config and all those things only prevent warp event to be scheduled and could not stop the warp events that are already scheduled. So I added some code to ignore actual warp event effect, when the player is having warp warding or creative or Thaumcraft wuss config. But Warp events scheduled from eating pure tears will still ignore the Warp Warding. ( This can be disabled by Config )