### PR TITLE
Remove countdown message and force doppelgänger to spawn on solid ground

### DIFF
--- a/src/main/java/shukaro/warptheory/handlers/warpevents/WarpCountdownBomb.java
+++ b/src/main/java/shukaro/warptheory/handlers/warpevents/WarpCountdownBomb.java
@@ -17,6 +17,11 @@ public class WarpCountdownBomb extends ITimerWarpEvent {
     }
 
     @Override
+    public void sendChatMessage(EntityPlayer player) {
+        // No message for this one.
+    }
+
+    @Override
     public int triggerEvent(int eventAmount, World world, EntityPlayer player) {
         setTimer(player, COUNTDOWN, 11);
         return 1;

--- a/src/main/java/shukaro/warptheory/handlers/warpevents/WarpCountdownBomb.java
+++ b/src/main/java/shukaro/warptheory/handlers/warpevents/WarpCountdownBomb.java
@@ -3,6 +3,7 @@ package shukaro.warptheory.handlers.warpevents;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import shukaro.warptheory.handlers.ITimerWarpEvent;
@@ -32,7 +33,8 @@ public class WarpCountdownBomb extends ITimerWarpEvent {
         if (timer.equals(COUNTDOWN)) {
             String color = timerCount > 5 ? FormatCodes.Purple.code : FormatCodes.Red.code;
             String format = timerCount > 2 ? FormatCodes.Italic.code : FormatCodes.Bold.code;
-            ChatHelper.sendToPlayer(player, color + format + timerCount);
+            String text = StatCollector.translateToLocal(String.format("chat.warptheory.%s.%d", name, timerCount));
+            ChatHelper.sendToPlayer(player, color + format + text);
 
             // Spawn some particles
             int numParticles = 8 * (10 - timerCount);

--- a/src/main/java/shukaro/warptheory/handlers/warpevents/WarpDoppelganger.java
+++ b/src/main/java/shukaro/warptheory/handlers/warpevents/WarpDoppelganger.java
@@ -17,7 +17,7 @@ public class WarpDoppelganger extends IWorldTickWarpEvent {
         int successful = 0;
 
         for (int i = 0; i < 6; i++) {
-            BlockCoord target = RandomBlockHelper.randomDoubleAirBlock(world, player, 4);
+            BlockCoord target = RandomBlockHelper.randomBlock(world, player, 4, block -> isValid(world, block));
             if (target == null) {
                 continue;
             }
@@ -35,5 +35,12 @@ public class WarpDoppelganger extends IWorldTickWarpEvent {
         }
 
         return successful;
+    }
+
+    private static boolean isValid(World world, BlockCoord block) {
+        BlockCoord below = block.copy().offset(0);
+        BlockCoord above = block.copy().offset(1);
+
+        return below.isTopSolid(world) && block.isAir(world) && above.isAir(world);
     }
 }

--- a/src/main/resources/assets/warptheory/lang/en_US.lang
+++ b/src/main/resources/assets/warptheory/lang/en_US.lang
@@ -80,6 +80,17 @@ chat.warptheory.wither=You feel overwhelmed with dread...
 # << GTNH new warp effects >>
 chat.warptheory.blazefireball=You feel a searing pain in your throat
 chat.warptheory.coin=You spot something shiny at your feet!
+chat.warptheory.countdownbomb.10=10
+chat.warptheory.countdownbomb.9=9
+chat.warptheory.countdownbomb.8=8
+chat.warptheory.countdownbomb.7=7
+chat.warptheory.countdownbomb.6=6
+chat.warptheory.countdownbomb.5=5
+chat.warptheory.countdownbomb.4=4
+chat.warptheory.countdownbomb.3=3
+chat.warptheory.countdownbomb.2=2
+chat.warptheory.countdownbomb.1=1
+chat.warptheory.countdownbomb.0=BOOM!
 chat.warptheory.doppelganger=You feel beside yourself...
 chat.warptheory.doppelganger.name=%s's Doppelgänger
 chat.warptheory.doppelganger.hurt=You feel your doppelgänger cry out

--- a/src/main/resources/assets/warptheory/lang/en_US.lang
+++ b/src/main/resources/assets/warptheory/lang/en_US.lang
@@ -80,7 +80,6 @@ chat.warptheory.wither=You feel overwhelmed with dread...
 # << GTNH new warp effects >>
 chat.warptheory.blazefireball=You feel a searing pain in your throat
 chat.warptheory.coin=You spot something shiny at your feet!
-chat.warptheory.countdown.bomb=You're about to explode! Get somewhere cheap!
 chat.warptheory.doppelganger=You feel beside yourself...
 chat.warptheory.doppelganger.name=%s's Doppelgänger
 chat.warptheory.doppelganger.hurt=You feel your doppelgänger cry out

--- a/src/main/resources/assets/warptheory/lang/zh_CN.lang
+++ b/src/main/resources/assets/warptheory/lang/zh_CN.lang
@@ -80,6 +80,17 @@ chat.warptheory.wither=你感到惶恐而不知所措...
 # << GTNH new warp effects >>
 chat.warptheory.blazefireball=You feel a searing pain in your throat
 chat.warptheory.coin=You spot something shiny at your feet!
+chat.warptheory.countdownbomb.10=10
+chat.warptheory.countdownbomb.9=9
+chat.warptheory.countdownbomb.8=8
+chat.warptheory.countdownbomb.7=7
+chat.warptheory.countdownbomb.6=6
+chat.warptheory.countdownbomb.5=5
+chat.warptheory.countdownbomb.4=4
+chat.warptheory.countdownbomb.3=3
+chat.warptheory.countdownbomb.2=2
+chat.warptheory.countdownbomb.1=1
+chat.warptheory.countdownbomb.0=BOOM!
 chat.warptheory.doppelganger=You feel beside yourself...
 chat.warptheory.doppelganger.name=%s's Doppelgänger
 chat.warptheory.doppelganger.hurt=You feel your doppelgänger cry out

--- a/src/main/resources/assets/warptheory/lang/zh_CN.lang
+++ b/src/main/resources/assets/warptheory/lang/zh_CN.lang
@@ -80,7 +80,6 @@ chat.warptheory.wither=你感到惶恐而不知所措...
 # << GTNH new warp effects >>
 chat.warptheory.blazefireball=You feel a searing pain in your throat
 chat.warptheory.coin=You spot something shiny at your feet!
-chat.warptheory.countdown.bomb=You're about to explode! Get somewhere cheap!
 chat.warptheory.doppelganger=You feel beside yourself...
 chat.warptheory.doppelganger.name=%s's Doppelgänger
 chat.warptheory.doppelganger.hurt=You feel your doppelgänger cry out


### PR DESCRIPTION
Bombcar, what do you think about removing the countdown message? The idea is that the player won't immediately know what's going to happen, and has to either figure it out (by the TNT sound effect, or just that it's like a time bomb) or just be sufficiently freaked out to run to a safe place before it goes off.

Also, changed the doppelgänger to only spawn on solid ground, because otherwise it could spawn in mid-air while you're exploring the End, fall into the void, and do massive damage to you, and that's a bit more punishing than intended.