### PR TITLE
Add "safe" tainted sheep for tainted livestock rain warp effect

### DIFF
--- a/src/main/java/shukaro/warptheory/WarpTheory.java
+++ b/src/main/java/shukaro/warptheory/WarpTheory.java
@@ -17,6 +17,7 @@ import shukaro.warptheory.entity.EntityDoppelganger;
 import shukaro.warptheory.entity.EntityFakeCreeper;
 import shukaro.warptheory.entity.EntityPassiveCreeper;
 import shukaro.warptheory.entity.EntityPhantom;
+import shukaro.warptheory.entity.EntitySafeTaintSheep;
 import shukaro.warptheory.gui.WarpTab;
 import shukaro.warptheory.handlers.ConfigHandler;
 import shukaro.warptheory.handlers.WarpCommand;
@@ -91,6 +92,7 @@ public class WarpTheory {
         EntityRegistry.registerModEntity(EntityFakeCreeper.class, "creeperFake", 1, this, 160, 4, true);
         EntityRegistry.registerModEntity(EntityDoppelganger.class, "doppelganger", 2, this, 160, 4, true);
         EntityRegistry.registerModEntity(EntityPhantom.class, "phantom", 3, this, 160, 4, true);
+        EntityRegistry.registerModEntity(EntitySafeTaintSheep.class, "taintSheepSafe", 4, this, 160, 4, true);
 
         proxy.init();
     }

--- a/src/main/java/shukaro/warptheory/entity/EntitySafeTaintSheep.java
+++ b/src/main/java/shukaro/warptheory/entity/EntitySafeTaintSheep.java
@@ -39,13 +39,13 @@ public class EntitySafeTaintSheep extends EntityTaintSheep {
 
     @Override
     protected void updateAITasks() {
+        super.updateAITasks();
+        
         try {
             sheepTimerField.set(this, eatGrass.func_151499_f());
         } catch (IllegalAccessException e) {
             throw new RuntimeException(e);
         }
-
-        super.updateAITasks();
     }
 
     @Override

--- a/src/main/java/shukaro/warptheory/entity/EntitySafeTaintSheep.java
+++ b/src/main/java/shukaro/warptheory/entity/EntitySafeTaintSheep.java
@@ -1,0 +1,55 @@
+package shukaro.warptheory.entity;
+
+import net.minecraft.entity.ai.EntityAIAttackOnCollide;
+import net.minecraft.entity.ai.EntityAIEatGrass;
+import net.minecraft.entity.ai.EntityAILookIdle;
+import net.minecraft.entity.ai.EntityAISwimming;
+import net.minecraft.entity.ai.EntityAIWander;
+import net.minecraft.entity.ai.EntityAIWatchClosest;
+import net.minecraft.entity.passive.EntityVillager;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
+import thaumcraft.common.entities.monster.EntityTaintSheep;
+
+import java.lang.reflect.Field;
+
+/** A version of the tainted sheep that cannot spread taint. */
+public class EntitySafeTaintSheep extends EntityTaintSheep {
+    private final EntityAIEatGrass eatGrass = new EntityAIEatGrass(this);
+    private final Field sheepTimerField;
+
+    public EntitySafeTaintSheep(World world) {
+        super(world);
+        this.tasks.taskEntries.clear();
+        this.tasks.addTask(0, new EntityAISwimming(this));
+        this.tasks.addTask(2, new EntityAIAttackOnCollide(this, EntityPlayer.class, 1.0D, false));
+        this.tasks.addTask(4, new EntityAIAttackOnCollide(this, EntityVillager.class, 1.0D, true));
+        this.tasks.addTask(5, this.eatGrass);
+        this.tasks.addTask(7, new EntityAIWander(this, 1.0D));
+        this.tasks.addTask(8, new EntityAIWatchClosest(this, EntityPlayer.class, 8.0F));
+        this.tasks.addTask(8, new EntityAILookIdle(this));
+
+        try {
+            sheepTimerField = EntityTaintSheep.class.getDeclaredField("sheepTimer");
+            sheepTimerField.setAccessible(true);
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected void updateAITasks() {
+        try {
+            sheepTimerField.set(this, eatGrass.func_151499_f());
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+
+        super.updateAITasks();
+    }
+
+    @Override
+    public void eatGrassBonus() {
+        this.setSheared(false);
+    }
+}

--- a/src/main/java/shukaro/warptheory/handlers/warpevents/WarpLivestockRain.java
+++ b/src/main/java/shukaro/warptheory/handlers/warpevents/WarpLivestockRain.java
@@ -8,6 +8,7 @@ import net.minecraft.entity.passive.EntitySheep;
 import net.minecraft.entity.passive.EntitySquid;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
+import shukaro.warptheory.entity.EntitySafeTaintSheep;
 import shukaro.warptheory.handlers.IMultiWarpEvent;
 import shukaro.warptheory.util.BlockCoord;
 import shukaro.warptheory.util.RandomBlockHelper;
@@ -47,8 +48,10 @@ public class WarpLivestockRain extends IMultiWarpEvent {
                         case 2:
                             // There is a chance that some of these entities may survive, due to
                             // landing on an adjacent block.
-                            // Tainted sheep are capable of spreading taint, so be careful!
-                            victim = new EntityTaintSheep(world);
+                            //
+                            // Tainted sheep are capable of spreading taint, so instead, we use a
+                            // custom version of tainted sheep that cannot spread taint.
+                            victim = new EntitySafeTaintSheep(world);
                             break;
                         default:
                             victim = new EntityTaintChicken(world);

--- a/src/main/resources/assets/warptheory/lang/en_US.lang
+++ b/src/main/resources/assets/warptheory/lang/en_US.lang
@@ -23,6 +23,9 @@ item.warptheory.amulet.name=Purification Talisman
 item.warptheory.something.name=Hunk of Something
 item.warptheory.paper.name=Arcane Litmus Paper
 
+# << entity names >>
+entity.WarpTheory.taintSheepSafe.name=Tainted Sheep
+
 # << tooltips >>
 tooltip.warptheory.cleanserminor=It's missing something...
 tooltip.warptheory.cleanser=Crunchy

--- a/src/main/resources/assets/warptheory/lang/zh_CN.lang
+++ b/src/main/resources/assets/warptheory/lang/zh_CN.lang
@@ -23,6 +23,9 @@ item.warptheory.amulet.name=净化护身符
 item.warptheory.something.name=块状物
 item.warptheory.paper.name=奥术石蕊试纸
 
+# << entity names >>
+entity.WarpTheory.taintSheepSafe.name=腐化羊
+
 # << tooltips >>
 tooltip.warptheory.cleanserminor=它缺了些什么...
 tooltip.warptheory.cleanser=咔咔作响


### PR DESCRIPTION
Add a "safe" version of the tainted sheep, which cannot spread taint, and use that for the tainted livestock rain warp effect. This tainted sheep will still attack players and villagers, but eats grass like a regular sheep. You can even use it to farm purple wool!

 * Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/9411