### PR TITLE
count armor warp only if player has any other warp

### DIFF
--- a/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
@@ -133,6 +133,7 @@ public class WarpHandler {
     public static int getTotalWarp(EntityPlayer player) {
         String name = player.getDisplayName();
         int innerWarp = Knowledge.getWarpTotal(name);
+        if (innerWarp <= 0) return 0;
         int extraPerm = Knowledge.getWarpPerm(name) * (int) Math.max(0, ConfigHandler.permWarpMult - 1);
         int outerWarp = getWarpFromGear(player);
         return innerWarp + extraPerm + outerWarp;


### PR DESCRIPTION
A LuV player can clean all other warp except warp from armor. This makes magic armor considerably less useful than tech counter part. 