### PR TITLE
Fix handling of allowWarpEffects config and Warp Ward potion effect

### DIFF
--- a/src/main/java/shukaro/warptheory/WarpTheory.java
+++ b/src/main/java/shukaro/warptheory/WarpTheory.java
@@ -79,8 +79,7 @@ public class WarpTheory {
 
         WarpItems.initItems();
 
-        if (ConfigHandler.allowWarpEffects)
-            MinecraftForge.EVENT_BUS.register(new WarpEventHandler());
+        MinecraftForge.EVENT_BUS.register(new WarpEventHandler());
     }
 
     @Mod.EventHandler

--- a/src/main/java/shukaro/warptheory/handlers/WarpEventHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpEventHandler.java
@@ -14,8 +14,8 @@ public class WarpEventHandler {
     public void livingUpdate(LivingEvent.LivingUpdateEvent e) {
         if (e.entity instanceof EntityPlayer) {
             EntityPlayer player = (EntityPlayer) e.entity;
-            boolean appliable = !player.isPotionActive(potionWarpWardID) || (WarpHandler.getUnavoidableCount(player) > 0) && !wuss && !player.capabilities.isCreativeMode;
-            boolean tickflag = !player.worldObj.isRemote && player.ticksExisted > 0 && player.ticksExisted % 2000 == 0;
+            boolean appliable = (!player.isPotionActive(potionWarpWardID) || WarpHandler.getUnavoidableCount(player) > 0) && !wuss && !player.capabilities.isCreativeMode;
+            boolean tickflag = ConfigHandler.allowWarpEffects && !player.worldObj.isRemote && player.ticksExisted > 0 && player.ticksExisted % 2000 == 0;
             if (tickflag && appliable && WarpHandler.getTotalWarp(player) > 0 && player.worldObj.rand.nextInt(100) <= Math.sqrt(WarpHandler.getTotalWarp(player))) {
                 IWarpEvent event = WarpHandler.queueOneEvent(player, WarpHandler.getTotalWarp(player));
                 if (event != null) {


### PR DESCRIPTION
allowWarpEffects is documented as "If false extra effects will only be seen when using Pure Tear" however the current implementation makes it so that the extra effects will **never** be seen. Using Pure Tear or any of the other warp removal items this mod adds will queue effects, but the queue will never be processed because the tick handler is never registered. Fix that by always registering the tick handler, and checking the config value for allowWarpEffects only when seeing if we should do a periodic effect (as opposed to an effect caused by an item).

Additionally, the check for the Warp Ward potion effect (bypassable via Pure Tear by default with disableRebound=false in config) had a misplaced parenthesis that ended up causing effects to always activate even when in Creative mode. This has an impact on testing worlds where one may want to cheat in TC research by making the player then wait through a gauntlet of crap for the queue to finish. Now, being in Creative will properly suppress the effects although switching back to Survival before the queue empties will still fire any remaining items in there; I think that's probably fine but also fixable if desired.