### PR TITLE
Fix spawned doppelgänger

### DIFF
--- a/src/main/java/shukaro/warptheory/entity/EntityDoppelganger.java
+++ b/src/main/java/shukaro/warptheory/entity/EntityDoppelganger.java
@@ -255,13 +255,16 @@ public class EntityDoppelganger extends EntityCreature implements IHealable, IHu
             return Optional.empty();
         }
 
-        String uuid = dataWatcher.getWatchableObjectString(UUID_DATA_WATCHER_ID);
-        UUID uuidObj = UUID.fromString(uuid);
+        String uuidString = dataWatcher.getWatchableObjectString(UUID_DATA_WATCHER_ID);
+        if (uuidString.isEmpty()) {
+            return Optional.empty();
+        }
+        UUID uuid = UUID.fromString(uuidString);
 
         @SuppressWarnings("unchecked")
         List<EntityPlayerMP> players = MinecraftServer.getServer().getConfigurationManager().playerEntityList;
         for (EntityPlayerMP entityPlayer : players) {
-            if (entityPlayer.getUniqueID().equals(uuidObj)) {
+            if (entityPlayer.getUniqueID().equals(uuid)) {
                 return Optional.of(entityPlayer);
             }
         }


### PR DESCRIPTION
Fix for doppelgängers spawned via unconventional means, causing a crash due to not handling empty UUID string.

Fixes:
 * https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13414