### PR TITLE
Fix crash with CombatHotbar

### DIFF
--- a/src/main/java/shukaro/warptheory/handlers/warpevents/WarpInventoryScramble.java
+++ b/src/main/java/shukaro/warptheory/handlers/warpevents/WarpInventoryScramble.java
@@ -19,6 +19,12 @@ public class WarpInventoryScramble extends IWarpEvent {
     }
 
     @Override
+    public boolean canDo(World world, EntityPlayer player) {
+        // Combat Hotbar slots are not in the main inventory.
+        return player.inventory.currentItem < player.inventory.mainInventory.length;
+    }
+
+    @Override
     public boolean doEvent(World world, EntityPlayer player) {
         if (world.isRemote) return true;
 

--- a/src/main/java/shukaro/warptheory/handlers/warpevents/WarpInventorySwap.java
+++ b/src/main/java/shukaro/warptheory/handlers/warpevents/WarpInventorySwap.java
@@ -33,7 +33,8 @@ public class WarpInventorySwap extends IWarpEvent {
             }
         }
 
-        boolean canSwapHandItem = player.inventory.getCurrentItem() != null && !emptySlots.isEmpty();
+        boolean canSwapHandItem = player.inventory.getCurrentItem() != null && !emptySlots.isEmpty()
+                && player.inventory.currentItem < player.inventory.mainInventory.length;
         boolean canSwapInventory = !fullSlots.isEmpty();
         if (canSwapHandItem && canSwapInventory) {
             // Pick one of the two to do.


### PR DESCRIPTION
WarpInventorySwap and WarpInventoryScramble assume that the currentItem is in the mainInventory. This is not the case when a CombatHotbar slot is selected, which will crash the game.
(Note that manually forcing a Warp event with `/warptheory` ignores the `canDo` check, but command errors are handled anyway so it still won't crash)

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15317