### PR TITLE
Warp Event Handler Cleanup

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -41,11 +41,11 @@ developmentEnvironmentUserName = Developer
 
 # Enables using modern Java syntax (up to version 17) via Jabel, while still targeting JVM 8.
 # See https://github.com/bsideup/jabel for details on how this works.
-enableModernJavaSyntax = false
+enableModernJavaSyntax = true
 
 # Enables injecting missing generics into the decompiled source code for a better coding experience.
 # Turns most publicly visible List, Map, etc. into proper List<E>, Map<K, V> types.
-enableGenericInjection = false
+enableGenericInjection = true
 
 # Generate a class with a String field for the mod version named as defined below.
 # If generateGradleTokenClass is empty or not missing, no such class will be generated.

--- a/src/main/java/shukaro/warptheory/handlers/WarpCommand.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpCommand.java
@@ -128,8 +128,7 @@ public class WarpCommand implements ICommand {
             return completions;
         } else if (args.length == 2) {
             ArrayList<String> completions = new ArrayList<String>();
-            for (EntityPlayer serverPlayer : (ArrayList<EntityPlayer>) MinecraftServer.getServer()
-                    .getConfigurationManager().playerEntityList) {
+            for (EntityPlayer serverPlayer : MinecraftServer.getServer().getConfigurationManager().playerEntityList) {
                 if (serverPlayer.getCommandSenderName().startsWith(args[1]))
                     completions.add(serverPlayer.getCommandSenderName());
             }

--- a/src/main/java/shukaro/warptheory/handlers/WarpEventHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpEventHandler.java
@@ -34,7 +34,8 @@ public class WarpEventHandler {
         Random rand = world.rand;
 
         if (ticks % 2000 == 0 && warpCounter > 0 && rand.nextInt(100) <= Math.sqrt(warpCounter)) {
-            IWarpEvent queuedEvent = WarpHandler.queueOneEvent(player, warpCounter);
+            int effectiveWarp = (WarpHandler.getTotalWarp(player) * 2 + warpCounter) / 3;
+            IWarpEvent queuedEvent = WarpHandler.queueOneEvent(player, effectiveWarp);
             if (queuedEvent != null) {
                 int tempWarp = WarpHandler.getIndividualWarps(player)[2];
                 if (tempWarp > 0) {

--- a/src/main/java/shukaro/warptheory/handlers/WarpEventHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpEventHandler.java
@@ -24,10 +24,11 @@ public class WarpEventHandler {
         boolean tickflag = ConfigHandler.allowWarpEffects && !player.worldObj.isRemote
                 && player.ticksExisted > 0
                 && player.ticksExisted % 2000 == 0;
+        int warpCounter = WarpHandler.Knowledge.getWarpCounter(player.getCommandSenderName());
         if (tickflag && appliable
-                && WarpHandler.getTotalWarp(player) > 0
-                && player.worldObj.rand.nextInt(100) <= Math.sqrt(WarpHandler.getTotalWarp(player))) {
-            IWarpEvent event = WarpHandler.queueOneEvent(player, WarpHandler.getTotalWarp(player));
+                && warpCounter > 0
+                && player.worldObj.rand.nextInt(100) <= Math.sqrt(warpCounter)) {
+            IWarpEvent event = WarpHandler.queueOneEvent(player, warpCounter);
             if (event != null) {
                 int warpTemp = WarpHandler.getIndividualWarps(player)[2];
                 if (warpTemp > 0 && event.getCost() <= warpTemp) WarpHandler.removeWarp(player, event.getCost());

--- a/src/main/java/shukaro/warptheory/handlers/WarpEventHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpEventHandler.java
@@ -35,6 +35,7 @@ public class WarpEventHandler {
 
         if (ticks % 2000 == 0 && warpCounter > 0 && rand.nextInt(100) <= Math.sqrt(warpCounter)) {
             int effectiveWarp = (WarpHandler.getTotalWarp(player) * 2 + warpCounter) / 3;
+            effectiveWarp -= WarpHandler.faceplateReduction(player);
             IWarpEvent queuedEvent = WarpHandler.queueOneEvent(player, effectiveWarp);
             if (queuedEvent != null) {
                 int tempWarp = WarpHandler.getIndividualWarps(player)[2];

--- a/src/main/java/shukaro/warptheory/handlers/WarpEventHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpEventHandler.java
@@ -16,29 +16,29 @@ public class WarpEventHandler {
 
     @SubscribeEvent
     public void livingUpdate(LivingEvent.LivingUpdateEvent e) {
-        if (e.entity instanceof EntityPlayer) {
-            EntityPlayer player = (EntityPlayer) e.entity;
-            boolean appliable = (!player.isPotionActive(potionWarpWardID)
-                    || WarpHandler.getUnavoidableCount(player) > 0) && !wuss && !player.capabilities.isCreativeMode;
-            boolean tickflag = ConfigHandler.allowWarpEffects && !player.worldObj.isRemote
-                    && player.ticksExisted > 0
-                    && player.ticksExisted % 2000 == 0;
-            if (tickflag && appliable
-                    && WarpHandler.getTotalWarp(player) > 0
-                    && player.worldObj.rand.nextInt(100) <= Math.sqrt(WarpHandler.getTotalWarp(player))) {
-                IWarpEvent event = WarpHandler.queueOneEvent(player, WarpHandler.getTotalWarp(player));
-                if (event != null) {
-                    int warpTemp = WarpHandler.getIndividualWarps(player)[2];
-                    if (warpTemp > 0 && event.getCost() <= warpTemp) WarpHandler.removeWarp(player, event.getCost());
-                    else if (warpTemp > 0) WarpHandler.removeWarp(player, warpTemp);
-                }
+        if (!(e.entity instanceof EntityPlayer player)) {
+            return;
+        }
+        boolean appliable = (!player.isPotionActive(potionWarpWardID)
+                || WarpHandler.getUnavoidableCount(player) > 0) && !wuss && !player.capabilities.isCreativeMode;
+        boolean tickflag = ConfigHandler.allowWarpEffects && !player.worldObj.isRemote
+                && player.ticksExisted > 0
+                && player.ticksExisted % 2000 == 0;
+        if (tickflag && appliable
+                && WarpHandler.getTotalWarp(player) > 0
+                && player.worldObj.rand.nextInt(100) <= Math.sqrt(WarpHandler.getTotalWarp(player))) {
+            IWarpEvent event = WarpHandler.queueOneEvent(player, WarpHandler.getTotalWarp(player));
+            if (event != null) {
+                int warpTemp = WarpHandler.getIndividualWarps(player)[2];
+                if (warpTemp > 0 && event.getCost() <= warpTemp) WarpHandler.removeWarp(player, event.getCost());
+                else if (warpTemp > 0) WarpHandler.removeWarp(player, warpTemp);
             }
-            if (player.ticksExisted % 20 == 0 && player.worldObj.rand.nextBoolean()) {
-                IWarpEvent event = WarpHandler.dequeueEvent(player);
-                WarpHandler.addUnavoidableCount(player, -1);
-                if (event != null && event.canDo(player.worldObj, player) && appliable)
-                    event.doEvent(player.worldObj, player);
-            }
+        }
+        if (player.ticksExisted % 20 == 0 && player.worldObj.rand.nextBoolean()) {
+            IWarpEvent event = WarpHandler.dequeueEvent(player);
+            WarpHandler.addUnavoidableCount(player, -1);
+            if (event != null && event.canDo(player.worldObj, player) && appliable)
+                event.doEvent(player.worldObj, player);
         }
     }
 

--- a/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
@@ -240,7 +240,7 @@ public class WarpHandler {
     public static int faceplateReduction(EntityPlayer player) {
         NBTTagCompound helmetTag = player.inventory.armorInventory[0].stackTagCompound;
         if (helmetTag != null && helmetTag.hasKey("mask") && helmetTag.getInteger("mask") == 0) {
-            return player.worldObj.rand.nextInt(2, 7);
+            return 2 + player.worldObj.rand.nextInt(5);
         }
         return 0;
     }

--- a/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
@@ -238,7 +238,9 @@ public class WarpHandler {
     }
 
     public static int faceplateReduction(EntityPlayer player) {
-        NBTTagCompound helmetTag = player.inventory.armorInventory[0].stackTagCompound;
+        ItemStack helmet = player.inventory.armorInventory[0];
+        if (helmet == null) return 0;
+        NBTTagCompound helmetTag = helmet.stackTagCompound;
         if (helmetTag != null && helmetTag.hasKey("mask") && helmetTag.getInteger("mask") == 0) {
             return 2 + player.worldObj.rand.nextInt(5);
         }

--- a/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
@@ -173,7 +173,7 @@ public class WarpHandler {
         int w = getFinalWarp(player.getCurrentEquippedItem(), player);
         for (int a = 0; a < 4; a++) w += getFinalWarp(player.inventory.armorItemInSlot(a), player);
         IInventory baubles = BaublesApi.getBaubles(player);
-        for (int i = 0; i < 4; i++) w += getFinalWarp(baubles.getStackInSlot(i), player);
+        for (int i = 0; i < baubles.getSizeInventory(); i++) w += getFinalWarp(baubles.getStackInSlot(i), player);
         return w;
     }
 

--- a/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
+++ b/src/main/java/shukaro/warptheory/handlers/WarpHandler.java
@@ -12,6 +12,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.StatCollector;
 
 import baubles.api.BaublesApi;
@@ -234,5 +235,13 @@ public class WarpHandler {
         UUID uuid = player.getUniqueID();
         if (!Unavoidable.containsKey(uuid)) Unavoidable.put(uuid, 0);
         return Unavoidable.get(uuid);
+    }
+
+    public static int faceplateReduction(EntityPlayer player) {
+        NBTTagCompound helmetTag = player.inventory.armorInventory[0].stackTagCompound;
+        if (helmetTag != null && helmetTag.hasKey("mask") && helmetTag.getInteger("mask") == 0) {
+            return player.worldObj.rand.nextInt(2, 7);
+        }
+        return 0;
     }
 }

--- a/src/main/java/shukaro/warptheory/handlers/warpevents/WarpMushrooms.java
+++ b/src/main/java/shukaro/warptheory/handlers/warpevents/WarpMushrooms.java
@@ -1,6 +1,5 @@
 package shukaro.warptheory.handlers.warpevents;
 
-import java.util.List;
 import java.util.Set;
 
 import net.minecraft.entity.Entity;

--- a/src/main/java/shukaro/warptheory/handlers/warpevents/WarpMushrooms.java
+++ b/src/main/java/shukaro/warptheory/handlers/warpevents/WarpMushrooms.java
@@ -69,7 +69,7 @@ public class WarpMushrooms extends IWorldTickWarpEvent {
                 (double) target.x + 1,
                 (double) target.y + 1,
                 (double) target.z + 1);
-        for (Entity entity : (List<Entity>) world.getEntitiesWithinAABB(EntityCow.class, boundingBox)) {
+        for (Entity entity : world.getEntitiesWithinAABB(EntityCow.class, boundingBox)) {
             // Check for exact class match, because we don't want to transform subclasses.
             if (entity.getClass() == EntityCow.class) {
                 EntityMooshroom mooshroom = new EntityMooshroom(world);

--- a/src/main/java/shukaro/warptheory/util/MiscHelper.java
+++ b/src/main/java/shukaro/warptheory/util/MiscHelper.java
@@ -21,16 +21,14 @@ import shukaro.warptheory.handlers.WarpHandler;
 public class MiscHelper {
 
     public static EntityPlayer getPlayerByName(String name) {
-        for (EntityPlayer serverPlayer : (ArrayList<EntityPlayer>) MinecraftServer.getServer()
-                .getConfigurationManager().playerEntityList) {
+        for (EntityPlayer serverPlayer : MinecraftServer.getServer().getConfigurationManager().playerEntityList) {
             if (serverPlayer.getCommandSenderName().equals(name)) return serverPlayer;
         }
         return null;
     }
 
     public static EntityPlayer getPlayerByEntityID(int id) {
-        for (EntityPlayer serverPlayer : (ArrayList<EntityPlayer>) MinecraftServer.getServer()
-                .getConfigurationManager().playerEntityList) {
+        for (EntityPlayer serverPlayer : MinecraftServer.getServer().getConfigurationManager().playerEntityList) {
             if (serverPlayer.getEntityId() == id) return serverPlayer;
         }
         return null;


### PR DESCRIPTION
Clean up the system that queues and dequeues WT warp events for players.

Notable behavior changes are:
Get equipment warp from all bauble slots, not just the first 4.
Reduce warp event severity by 2-6 with the Grinning Devil Faceplate for fortress armor (same source as below).
Use Thaum's warp counter to scale the frequency and severity of warp events. Frequency replaces a direct check against the player's total warp and severity uses the formula shown here https://thaumcraft-4.fandom.com/wiki/Warp#Event_selection_and_severity. This makes WT events taper off like base Thaum events until more warp is gained, bringing them more in line with them. Notably, WT events will NOT lower the warp counter, so base Thaum events should be entirely unaffected and will still need to fire to reduce the counter. I could be convinced to change this and make them lower the counter. Maybe at a reduced rate compared to Thaum events to keep them more punishing?